### PR TITLE
TE-2218 Solve NPM install warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,10 @@
   "files": [
     "lib"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/lodgify/enzyme-jest-expect-helpers.git"
+  },
   "scripts": {
     "build:js": "BABEL_ENV=production babel expect-helpers/ -d lib/",
     "build": "npm run clean && npm run build:js",
@@ -18,9 +22,9 @@
   "author": "Lodgify",
   "license": "MIT",
   "peerDependencies": {
-    "enzyme": "^3.3.0",
+    "enzyme": ">= 3",
     "enzyme-adapter-react-16": "^1.1.1",
-    "jest": "^22.4.3"
+    "jest": ">= 23"
   },
   "devDependencies": {
     "babel-cli": "^6.26.0",


### PR DESCRIPTION
[Related YouTrack issue](https://youtrack.lodgify.net/issue/TE-2218)

### What **one** thing does this PR do?
Installs the right versions of `jest` and `enzyme` to get rid of npm warnings; additionally, adds missing repository to `package.json`

### Any other notes.

Leaves on error unhandled as it requires other multiple peer dependencies to be solved. Perhaps another card?
![Screenshot 2019-06-04 at 17 47 43](https://user-images.githubusercontent.com/33876435/58893670-e001d400-86f0-11e9-9e29-784602527101.png)

